### PR TITLE
fix: full bound checking

### DIFF
--- a/execinquery.go
+++ b/execinquery.go
@@ -31,10 +31,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	result.Preorder(nodeFilter, func(n ast.Node) {
 		switch n := n.(type) {
 		case *ast.CallExpr:
-			if len(n.Args) < 1 {
-				return
-			}
-
 			selector, ok := n.Fun.(*ast.SelectorExpr)
 			if !ok {
 				return
@@ -51,6 +47,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			var i int
 			if strings.Contains(selector.Sel.Name, "Context") {
 				i = 1
+			}
+
+			if len(n.Args) <= i {
+				return
 			}
 
 			var s string


### PR DESCRIPTION
The current tool can still panic with something like the following code. This PR should fix it. This really closes #3.
```go
a.QueryContext(0)
```
That is, the tool could still panic when `len(n.Args)` is exactly one and the method name contains the string `Context`.