### PR TITLE
fix: panic of nil pointer dereference "pass.TypesInfo" and "package check"

### DIFF
--- a/execinquery.go
+++ b/execinquery.go
@@ -49,6 +49,10 @@ func (l linter) run(pass *analysis.Pass) (interface{}, error) {
 				return
 			}
 
+			if pass.TypesInfo == nil || pass.TypesInfo.Uses[selector.Sel] == nil || pass.TypesInfo.Uses[selector.Sel].Pkg() == nil {
+				return
+			}
+
 			if "database/sql" != pass.TypesInfo.Uses[selector.Sel].Pkg().Path() {
 				return
 			}
@@ -60,7 +64,7 @@ func (l linter) run(pass *analysis.Pass) (interface{}, error) {
 			replacement := "Exec"
 			var i int // the index of the query argument
 			if strings.Contains(selector.Sel.Name, "Context") {
-				replacement = "ExecContext"
+				replacement += "Context"
 				i = 1
 			}
 

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -3,6 +3,7 @@ package a
 import (
 	"context"
 	"database/sql"
+	"errors"
 )
 
 const selectWithComment = `-- foobar
@@ -58,4 +59,7 @@ UPDATE * FROM test WHERE test=?`
 	f5 := `
 UPDATE * ` + `FROM test` + ` WHERE test=?`
 	_ = db.QueryRow(f5, s) // want "Use Exec instead of QueryRow to execute `UPDATE` query"
+
+	err := errors.New("oops")
+	err.Error()
 }


### PR DESCRIPTION
```console
$ go vet -vettool=$(which execinquery) ./...

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x61d0c2]

goroutine 18 [running]:
go/types.(*Package).Path(...)
        /home/ldez/.gvm/gos/go1.18.1/src/go/types/package.go:31
github.com/lufeee/execinquery.linter.run.func1({0x6d8218?, 0xc000132700})
        /home/ldez/sources/go/src/github.com/lufeee/execinquery/execinquery.go:56 +0xc2
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc0002a96e0, {0xc00009ac80?, 0x1?, 0x7f18bc19c5b8?}, 0xc00009ac90)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.1.9/go/ast/inspector/inspector.go:77 +0x9a
github.com/lufeee/execinquery.linter.run({0xc0000de5a0?, 0xc0000de6e0?}, 0xc0002b5ad0)
        /home/ldez/sources/go/src/github.com/lufeee/execinquery/execinquery.go:44 +0xd5
golang.org/x/tools/go/analysis/unitchecker.run.func5.1()
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.1.9/go/analysis/unitchecker/unitchecker.go:355 +0x82e
sync.(*Once).doSlow(0x0?, 0x0?)
        /home/ldez/.gvm/gos/go1.18.1/src/sync/once.go:68 +0xc2
sync.(*Once).Do(...)
        /home/ldez/.gvm/gos/go1.18.1/src/sync/once.go:59
golang.org/x/tools/go/analysis/unitchecker.run.func5(0x81f980?)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.1.9/go/analysis/unitchecker/unitchecker.go:307 +0x1a5
golang.org/x/tools/go/analysis/unitchecker.run.func6.1(0x0?)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.1.9/go/analysis/unitchecker/unitchecker.go:367 +0x29
created by golang.org/x/tools/go/analysis/unitchecker.run.func6
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.1.9/go/analysis/unitchecker/unitchecker.go:366 +0x47
```