### PR TITLE
fix: Panic when Ident has no Obj

### DIFF
--- a/execinquery.go
+++ b/execinquery.go
@@ -116,6 +116,9 @@ func (l linter) getQueryString(exp interface{}) string {
 		return v
 
 	case *ast.Ident:
+		if e.Obj == nil {
+			return ""
+		}
 		return l.getQueryString(e.Obj.Decl)
 
 	case *ast.BinaryExpr:

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -37,6 +37,8 @@ func sample(db *sql.DB) {
 	_, _ = db.QueryContext(context.Background(), "UPDATE * FROM test WHERE test=?", s) // want "Use ExecContext instead of QueryContext to execute `UPDATE` query"
 	_ = db.QueryRow("UPDATE * FROM test WHERE test=?", s)                              // want "Use Exec instead of QueryRow to execute `UPDATE` query"
 
+	_, _ = db.Query(otherFileValue, s)
+
 	query := "UPDATE * FROM test where test=?"
 	_, _ = db.Query(query, s) // want "Use Exec instead of Query to execute `UPDATE` query"
 

--- a/testdata/src/a/b.go
+++ b/testdata/src/a/b.go
@@ -1,0 +1,3 @@
+package a
+
+const otherFileValue = "UPDATE * FROM test where test=?"


### PR DESCRIPTION
For some reason when the Ident is in another file in the
same package, the ast package does not provide an obj.
Avoid a panic that happens when trying to access the nil Obj.

This means the value cannot be tested for an exec, but at least
execinquery no longer crashes.